### PR TITLE
The yaw is in [deg] so the unit='deg' must be passed to the ssa function

### DIFF
--- a/mssExamples/ExKF.m
+++ b/mssExamples/ExKF.m
@@ -84,7 +84,7 @@ for i=1:N+1
        
        % corrector
        P_hat = IKC * P_prd * IKC' + K * Rd * K';   
-       x_hat = x_prd + K * ssa(y - Cd * x_prd);   % smallest signed angle
+       x_hat = x_prd + K * ssa(y - Cd * x_prd, 'deg');   % smallest signed angle
    else
        P_hat =P_prd;                % no measurement
        x_hat = x_prd;


### PR DESCRIPTION
Thanks a lot for this fantastic examples, that have been a great asset to me when learning about Kalman Filters for my PhD studies.

I found this error when I was experimenting with the example giving the filter a poor initial guess:
x_prd=[10,0]

...the filter was unable to correct for this poor initial guess, and I found that mixing radians and deg was the cause.