### PR TITLE
Ad and Bd are linearized at the current state in the EKF. Ad and Bd h…

### DIFF
--- a/mssExamples/ExEKF.m
+++ b/mssExamples/ExEKF.m
@@ -89,20 +89,20 @@ for i=1:N+1
    
    % store simulation data in a table   
    simdata(i,:) = [t x' x_hat' P_hat(1,1) P_hat(2,2) ];    
-
-   % discrete-time extended KF-model
-   f_hat = [ x_hat(2)
-             a * x_hat(2) * abs(x_hat(2)) + b * u ];
-   f_d   = x_hat + h * f_hat;
       
    % Predictor (k+1)  
    % Ad = I + h * A and Ed = h * E
    % where A = df/dx is linearized about x = x_hat
    Ad   = [ 1   h
-             0  1 + h*2*a*abs(x_hat(2)) ];   
+            0   1 + h*a*abs(x_hat(2)) ];   
    Ed = h * E; 
    
-   x_prd = f_d;
+   Bd = [0;
+         b*h];
+   
+   x_prd = Ad*x_hat + Bd*u;
+   
+   
    P_prd = Ad * P_hat * Ad' + Ed * Qd * Ed';
    
    % Euler integration (k+1)


### PR DESCRIPTION
I'm trying to implement EKF (or rather RTS smoother) for parameter identification of ship manoeuvring. This toolbox has been a great help for me, so thanks a lot!

I added this PR to see if I have understood the EKF correctly (by proposing some changes to one of the examples).  
My understanding of the EKF is that the transition matrixes are linearized at the current state for each iteration.  In order to make this more clear, I have replaced the prediction step:
`x_prd = f_d`
 with
`x_prd = Ad*x_hat + Bd*u;`

Where Ad and Bd are the linearized matrixes, so that the rest of the filter works exactly the same as the regular KF.
It would be very nice for me to get some feedback to enhance my understanding of this topic.

(Rewriting the filter in this way made it easier for me to also implement the RTS smoother)