### PR TITLE
Fix prolate spheroid eccentricity calculation

### DIFF
--- a/GNC/imlay61.m
+++ b/GNC/imlay61.m
@@ -47,7 +47,7 @@ end
 MA_44 = r44 * Ix; 
 
 % Lamb's k-factors
-e = 1-(b/a)^2;
+e = sqrt(1-(b/a)^2);
 alpha_0 = ( 2 * (1-e^2)/e^3 ) * ( 0.5 * log((1+e)/(1-e)) - e );  
 beta_0  = 1/e^2 - (1-e^2)/(2*e^3) * log((1+e)/(1-e)); 
 


### PR DESCRIPTION
As per _Imlay 1961_, page 16 - eq. 15: 
```
e² = 1 - (b/a)²
```
As the extracted section below:

![image](https://user-images.githubusercontent.com/20045837/163475695-8ee0ce52-8936-468a-9e16-e88a96f2d6cb.png)

This might have passed unnoticed because the previous calculation was also a number below (and usually close to) one, whose squared root is also below one. 

I've only noticed a difference after developing the expressions for a generic ellipsoid: `a > b >= c` using the integrals to calculate `alpha0`, `beta0` and `gamma0` as in _Lamb, Horace. Hydrodynamics_ (page 153) 