### PR TITLE
Updated ALOS3D to use wpt.pos.z to get zk for first active waypoint.

### DIFF
--- a/GNC/ALOS3D.m
+++ b/GNC/ALOS3D.m
@@ -99,7 +99,7 @@ if isempty(k)
     k = 1;                % set first waypoint as the active waypoint
     xk = wpt.pos.x(k); 
     yk = wpt.pos.y(k);  
-    zk = wpt.pos.y(k);     
+    zk = wpt.pos.z(k);     
     fprintf('Active waypoints:\n')
     fprintf('  (x%1.0f,y%1.0f,z%1.0f) = (%.1f,%.1f,%.1f) \n',k,k,k,xk,yk,zk);
 


### PR DESCRIPTION
Excuse me if I've misunderstood something here, but I believe that there may be a typo in ALOS3D.m. 
I've submitted a pull request to fix the issue.